### PR TITLE
Add capability for private subnets

### DIFF
--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -11,9 +11,7 @@ resource "aws_security_group" "home_dirs_sg" {
 
   # NFS
   ingress {
-
-    # FIXME: Is ther a way to do this without CIDR block copy/pasta
-    cidr_blocks = [ "172.16.0.0/16"]
+    cidr_blocks = [ var.cidr ]
     # FIXME: Do we need this security_groups here along with cidr_blocks
     security_groups = [ module.eks.worker_security_group_id ]
     from_port        = 2049

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -35,3 +35,27 @@ variable "map_users" {
   default = [
   ]
 }
+
+variable "use_private_subnets" {
+    description = "Use private subnets for EKS worker nodes."
+    type        = bool
+    default = false
+}
+
+variable "public_subnets" {  
+    description = "Public subnet IP ranges."
+    type        = list(string)
+    default = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+}
+
+variable "private_subnets" {  
+    description = "Private subnet IP ranges."
+    type        = list(string)
+    default = []   #   ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+}
+
+variable "cidr" {
+    description = "IP range of subnets"
+    type = string
+    default = "172.16.0.0/16"
+}


### PR DESCRIPTION
This introduces support for creating private subnets instead of public ones.  These are the subnets that the cluster will be deployed in.