### PR TITLE
Unmanaged vpc 2

### DIFF
--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -6,12 +6,12 @@ resource "aws_efs_file_system" "home_dirs" {
 
 
 resource "aws_security_group" "home_dirs_sg" {
-  name   = "home_dirs_sg"
-  vpc_id = module.vpc.vpc_id
+  name   = "${var.cluster_name}-home_dirs_sg"
+  vpc_id = local.vpc_id
 
   # NFS
   ingress {
-    cidr_blocks = [ var.cidr ]
+    cidr_blocks = [ var.vpc_cidr ]
     # FIXME: Do we need this security_groups here along with cidr_blocks
     security_groups = [ module.eks.worker_security_group_id ]
     from_port        = 2049
@@ -20,10 +20,12 @@ resource "aws_security_group" "home_dirs_sg" {
   }
 }
 
+
+# XXXX should the EFS subnets be public or private?
 resource "aws_efs_mount_target" "home_dirs_targets" {
-  count = length(module.vpc.public_subnets)
+  count = length(local.public_subnet_ids)
   file_system_id = aws_efs_file_system.home_dirs.id
-  subnet_id = module.vpc.public_subnets[count.index]
+  subnet_id = local.public_subnet_ids[count.index]
   security_groups = [ aws_security_group.home_dirs_sg.id ]
 }
 
@@ -39,7 +41,7 @@ resource "kubernetes_namespace" "support" {
 }
 
 resource "helm_release" "efs-provisioner" {
-  name = "efs-provisioner"
+  name = "${var.cluster_name}-efs-provisioner"
   namespace = kubernetes_namespace.support.metadata.0.name
   repository = data.helm_repository.stable.metadata[0].name
   chart = "efs-provisioner"
@@ -73,3 +75,4 @@ resource "helm_release" "efs-provisioner" {
     value = "aws.amazon.com/efs"
   }
 }
+

--- a/aws/jmiller-hub.tfvars
+++ b/aws/jmiller-hub.tfvars
@@ -1,0 +1,51 @@
+# Put your cluster where your data is
+region = "us-east-1"
+
+map_users = []
+
+# See https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html for
+# more information
+map_roles = [{
+    rolearn  = "arn:aws:sts::328656936502:assumed-role/jupyterhub-deploy/i-02b0add7d3b133877"
+    username = "jmiller"
+    groups   = ["system:masters"]
+},{
+    rolearn  = "arn:aws:sts::328656936502:role/jupyterhub-deploy/i-02b0add7d3b133877"
+    username = "jmiller"
+    groups   = ["system:masters"]
+}]
+
+# Name of your cluster
+cluster_name = "jmiller-hub"
+
+# # ============================================================================================================
+
+# # Configured for unmanaged private subnets created by IT
+
+# use_private_subnets = true
+# create_vpc = false
+
+# vpc_cidr = "10.128.0.0/9"                        # managed or unmanaged for EKS and EFS.  single block only
+
+# unmanaged_vpc_id = "vpc-0609d0f2a72ccf96d"       # sandbox 
+# unmanaged_private_subnet_names = ["*Private*"]   # or e.g. "*DMZ*", can be patterns or literal
+
+# # cluster_create_security_group = false
+# # cluster_security_group_id = "sg-0534a0b113cbd8501"                    # EKS cluster-to-cluster
+# worker_create_security_group = false
+# worker_additional_security_group_ids = ["sg-0a5f153ac7a17d80c"]       # Access to cluster, plugs into cluster_security_group_id
+# worker_security_group_id = "sg-0a42f0a8c84e73579"                     #
+
+
+# ============================================================================================================
+
+# Configured for managed private subnets created by Terraform
+
+use_private_subnets = true
+create_vpc = true
+
+vpc_cidr = "172.16.0.0/16"
+
+public_subnets =  ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+private_subnets = ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+

--- a/aws/jmiller-hub.tfvars
+++ b/aws/jmiller-hub.tfvars
@@ -10,30 +10,31 @@ allowed_roles = ["arn:aws:iam::328656936502:role/jupyterhub-deploy"]
 
 # # Configured for unmanaged private subnets created by IT
 
-# use_private_subnets = true
-# create_vpc = false
+use_private_subnets = true
+create_vpc = false
 
-# vpc_cidr = "10.128.0.0/9"                        # managed or unmanaged for EKS and EFS.  single block only
+vpc_cidr = "10.128.0.0/9"                        # managed or unmanaged for EKS and EFS.  single block only
 
-# unmanaged_vpc_id = "vpc-0609d0f2a72ccf96d"       # sandbox 
-# unmanaged_private_subnet_names = ["*Private*"]   # or e.g. "*DMZ*", can be patterns or literal
+unmanaged_vpc_id = "vpc-0609d0f2a72ccf96d"       # sandbox 
+unmanaged_private_subnet_names = ["*Private*"]   # or e.g. "*DMZ*", can be patterns or literal
 
-# # cluster_create_security_group = false
-# # cluster_security_group_id = "sg-0534a0b113cbd8501"                    # EKS cluster-to-cluster
-# worker_create_security_group = false
-# worker_additional_security_group_ids = ["sg-0a5f153ac7a17d80c"]       # Access to cluster, plugs into cluster_security_group_id
-# worker_security_group_id = "sg-0a42f0a8c84e73579"                     #
+cluster_create_security_group = false
+cluster_security_group_id = "sg-0dd1c6c4a19845d62"                    # EKS cluster-to-cluster
+worker_create_security_group = false
+worker_security_group_id = "sg-076fe0fda7e6809f4"                     #
+
+# worker_additional_security_group_ids = ["sg-0a5f153ac7a17d80c"]       # 
 
 
 # ============================================================================================================
 
 # Configured for managed private subnets created by Terraform
 
-use_private_subnets = true
-create_vpc = true
+# use_private_subnets = true
+# create_vpc = true
 
-vpc_cidr = "172.16.0.0/16"
+# vpc_cidr = "172.16.0.0/16"
 
-public_subnets =  ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
-private_subnets = ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+# public_subnets =  ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+# private_subnets = ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
 

--- a/aws/jmiller-hub.tfvars
+++ b/aws/jmiller-hub.tfvars
@@ -1,22 +1,10 @@
 # Put your cluster where your data is
 region = "us-east-1"
 
-map_users = []
-
-# See https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html for
-# more information
-map_roles = [{
-    rolearn  = "arn:aws:sts::328656936502:assumed-role/jupyterhub-deploy/i-02b0add7d3b133877"
-    username = "jmiller"
-    groups   = ["system:masters"]
-},{
-    rolearn  = "arn:aws:sts::328656936502:role/jupyterhub-deploy/i-02b0add7d3b133877"
-    username = "jmiller"
-    groups   = ["system:masters"]
-}]
-
 # Name of your cluster
 cluster_name = "jmiller-hub"
+
+allowed_roles = ["arn:aws:iam::328656936502:role/jupyterhub-deploy"]
 
 # # ============================================================================================================
 

--- a/aws/local.tf
+++ b/aws/local.tf
@@ -1,0 +1,34 @@
+locals {
+
+       # ====================================================================================
+       # Networking:  (managed, unmanaged vpc) x (public, private subnets)
+       # ====================================================================================
+
+       vpc_id = var.create_vpc ? lookup(module.vpc, "vpc_id") : var.unmanaged_vpc_id 
+
+       vpc_name = var.create_vpc ? lookup(module.vpc, "name") : local.unmanaged_vpc_name
+
+       eks_subnet_ids = var.create_vpc ? local.managed_subnet_ids : local.unmanaged_subnet_ids
+
+       managed_subnet_ids = var.use_private_subnets ? module.vpc.private_subnets : module.vpc.public_subnets
+
+       private_subnet_ids = var.create_vpc ? module.vpc.private_subnets : local.unmanaged_private_subnet_ids
+
+       public_subnet_ids =  var.create_vpc ? module.vpc.public_subnets : local.unmanaged_public_subnet_ids
+
+       unmanaged_vpc_name = data.aws_vpc.unmanaged[*] != [] ? data.aws_vpc.unmanaged[0].tags["Name"] : "UNDEFINED-vpc-name"
+
+       unmanaged_subnet_ids = var.use_private_subnets ? local.unmanaged_private_subnet_ids : local.unmanaged_public_subnet_ids
+       
+       unmanaged_public_subnet_ids = tolist((data.aws_subnet_ids.unmanaged_public[*].ids)[0])
+
+       unmanaged_private_subnet_ids = tolist((data.aws_subnet_ids.unmanaged_private[*].ids)[0])
+
+       private_subnet_cidrs  = var.create_vpc ? module.vpc.private_subnets : local.unmanaged_private_subnet_cidrs
+       public_subnet_cidrs  = var.create_vpc ? module.vpc.public_subnets : local.unmanaged_public_subnet_cidrs
+       unmanaged_private_subnet_cidrs = [for s in data.aws_subnet.unmanaged_private : s.cidr_block]
+       unmanaged_public_subnet_cidrs = [for s in data.aws_subnet.unmanaged_public : s.cidr_block]
+       unmanaged_private_subnet_names = [for s in data.aws_subnet.unmanaged_private : s.tags["Name"]]
+       unmanaged_public_subnet_names = [for s in data.aws_subnet.unmanaged_public : s.tags["Name"]]
+
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -37,7 +37,7 @@ module "eks" {
   cluster_name = var.cluster_name
   subnets      = local.eks_subnet_ids
   cluster_endpoint_private_access = true
-  cluster_endpoint_private_access_cidrs = local.private_subnet_cidrs
+  # cluster_endpoint_private_access_cidrs = local.private_subnet_cidrs
   vpc_id       = local.vpc_id
   enable_irsa  = true
   

--- a/aws/mktags
+++ b/aws/mktags
@@ -1,0 +1,16 @@
+#! /bin/bash  -x 
+
+cluster_name="jmiller-hub"
+vpc_id="vpc-0609d0f2a72ccf96d"
+public_subnet_ids="subnet-0e5478d300d15a00c subnet-0acbd0e839b582822 subnet-0980788a037ffd5d7"
+dmz_subnet_ids="subnet-0c19c68596b826f92 subnet-01458be8f15059eee subnet-0946b77db4de4d579"   
+private_subnet_ids="subnet-061c51be9ee131e6d subnet-0f049f5e66619aef4 subnet-0e0f36a4570f01b55"
+
+# aws ec2 create-tags --resources $vpc_id --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"  
+
+# aws ec2 create-tags --resources $public_subnet_ids --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"   "Key=kubernetes.io/role/elb,Value=1"
+
+aws ec2 create-tags --resources $private_subnet_ids --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"   "Key=kubernetes.io/role/internal-elb,Value=1"
+
+
+# also tagged API gateway with Key=kubernetes.io/cluster/${cluster_name},Value=shared

--- a/aws/mktags
+++ b/aws/mktags
@@ -6,11 +6,16 @@ public_subnet_ids="subnet-0e5478d300d15a00c subnet-0acbd0e839b582822 subnet-0980
 dmz_subnet_ids="subnet-0c19c68596b826f92 subnet-01458be8f15059eee subnet-0946b77db4de4d579"   
 private_subnet_ids="subnet-061c51be9ee131e6d subnet-0f049f5e66619aef4 subnet-0e0f36a4570f01b55"
 
-# aws ec2 create-tags --resources $vpc_id --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"  
+aws ec2 create-tags --resources $vpc_id --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"  
 
-# aws ec2 create-tags --resources $public_subnet_ids --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"   "Key=kubernetes.io/role/elb,Value=1"
+aws ec2 create-tags --resources $public_subnet_ids   --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared" 
+aws ec2 create-tags --resources $public_subnet_ids   --tags "Key=kubernetes.io/role/elb,Value=1"
 
-aws ec2 create-tags --resources $private_subnet_ids --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"   "Key=kubernetes.io/role/internal-elb,Value=1"
+aws ec2 create-tags --resources $dmz_subnet_ids     --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"
+aws ec2 create-tags --resources $dmz_subnet_ids     --tags "Key=kubernetes.io/role/internal-elb,Value=1"
+
+aws ec2 create-tags --resources $private_subnet_ids --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"
+aws ec2 create-tags --resources $private_subnet_ids --tags "Key=kubernetes.io/role/internal-elb,Value=1"
 
 
 # also tagged API gateway with Key=kubernetes.io/cluster/${cluster_name},Value=shared

--- a/aws/outputs-2.tf
+++ b/aws/outputs-2.tf
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------
+
+output unmanaged_vpc_id {
+       value = var.unmanaged_vpc_id
+}
+
+output vpc_cidr {
+       value = var.vpc_cidr
+}
+
+output unmanaged_vpc_name {
+       value = local.unmanaged_vpc_name
+}
+
+output eks_subnet_ids {
+       value = local.eks_subnet_ids
+}
+
+output unmanaged_public_subnet_ids {
+       value = local.unmanaged_public_subnet_ids
+}
+
+output unmanaged_private_subnet_ids {
+       value = local.unmanaged_private_subnet_ids
+}
+
+output public_subnet_cidrs {
+  value = local.public_subnet_cidrs
+}
+
+output unmanaged_public_subnet_names {
+  value = local.unmanaged_public_subnet_names
+}
+
+output private_subnet_cidrs {
+  value = local.private_subnet_cidrs
+}
+
+output unmanaged_private_subnet_names {
+  value = local.unmanaged_private_subnet_names
+}
+
+output worker_create_security_group {
+  value = var.worker_create_security_group
+}
+
+output worker_security_group_id {
+  value = var.worker_security_group_id
+}
+
+

--- a/aws/terraform.tfvars
+++ b/aws/terraform.tfvars
@@ -1,0 +1,1 @@
+jmiller-hub.tfvars

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -109,7 +109,7 @@ variable worker_security_group_id {
 variable worker_additional_security_group_ids {
    description = "Security group accepting 443 ingress from worker_security_group_id"
    type = list(string)
-   default = []
+   default = null
 }
 
 # ========================================================================

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -24,30 +24,109 @@ variable "map_roles" {
   ]
 }
 
-variable "use_private_subnets" {
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+
+  default = [
+  ]
+}
+
+# -------------------------------------------------------------------------
+#                     Networking config 
+
+# ========================================================================
+# Always define
+
+variable create_vpc {
+    description = "When true,  Terraform creates VPC, subnet, etc. resources"
+    type = bool
+    default = false   #  XXXX true
+}
+
+variable use_private_subnets {
     description = "Use private subnets for EKS worker nodes."
     type        = bool
-    default = false
+    default = true   # XXXX false
 }
 
-variable "public_subnets" {  
-    description = "Public subnet IP ranges."
-    type        = list(string)
-    default = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
-}
-
-variable "private_subnets" {  
-    description = "Private subnet IP ranges."
-    type        = list(string)
-    default = []   #   ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
-}
-
-variable "cidr" {
+variable vpc_cidr {
     description = "IP range of subnets"
     type = string
     default = "172.16.0.0/16"
 }
 
-variable "allowed_roles" {
+# ========================================================================
+# Define when create_vpc is false (i.e. for unmanaged (externally created)
+# vpc and subnets.
+
+variable unmanaged_vpc_id {
+   description = "ID of unmanaged VPC, e.g. created by IT department."
+   type = string
+   default = ""
+}
+
+variable unmanaged_public_subnet_names {
+   description = "Pattern applied to Name tag to select unmanaged public subnets from the unmanaged vpc"
+   type = list(string)
+   default = ["*Public*"]
+}
+
+variable unmanaged_private_subnet_names {
+   description = "Patterns applied to Name tag to select unmanaged private subnets from the unmanaged vpc"
+   type = list(string)
+   default = ["*Private*"]
+}
+
+variable cluster_create_security_group {
+   description = "If true,  EKS module should create security group for group-to-cluster accesss."
+   type = bool
+   default = true
+}
+
+variable cluster_security_group_id {
+   description = "ID of security group for EKS cluster self-trust."
+   type = string
+   default = null
+}
+
+variable worker_create_security_group {
+   description = "If true,  EKS module should create security group for accessing EKS endpoint for private workers and CI-nodes."
+   type = bool
+   default = true
+}
+
+variable worker_security_group_id {
+   description = "ID of security group to which EKS worker and terraform deployment nodes will be assigned."
+   type = string
+   default = null
+}
+
+variable worker_additional_security_group_ids {
+   description = "Security group accepting 443 ingress from worker_security_group_id"
+   type = list(string)
+   default = []
+}
+
+# ========================================================================
+# Define when create_vpc is true (i.e. for managed vpc and subnets)
+
+variable public_subnets {  
+    description = "Public subnet IP ranges."
+    type        = list(string)
+    default = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+}
+
+variable private_subnets {  
+    description = "Private subnet IP ranges."
+    type        = list(string)
+    default = []   #   ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+}
+
+variable allowed_roles {
     default = []
 }

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -1,0 +1,73 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.6"
+
+  create_vpc = var.create_vpc
+
+  name                 = "${var.cluster_name}-vpc"
+  cidr                 = var.vpc_cidr
+  azs                  = data.aws_availability_zones.available.names
+
+  # We can use private subnets too once https://github.com/aws/containers-roadmap/issues/607
+  # is fixed
+  public_subnets       = var.public_subnets
+  private_subnets      = var.private_subnets
+  
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  enable_nat_gateway   = var.use_private_subnets
+  single_nat_gateway   = var.use_private_subnets
+  
+  tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+}
+
+
+# =======================================================================
+
+data aws_vpc unmanaged {
+  count =  var.create_vpc ? 0 : 1
+  id = var.unmanaged_vpc_id
+}
+
+data aws_subnet_ids unmanaged_public {
+  # splat expr for conditional creation
+  vpc_id = var.unmanaged_vpc_id
+
+  filter {
+    name   = "tag:Name"
+    values = var.unmanaged_public_subnet_names         # can be patterns
+  }
+}
+
+data aws_subnet_ids unmanaged_private {
+  # splat expr for conditional creation
+  vpc_id = var.unmanaged_vpc_id
+
+  filter {
+    name   = "tag:Name"
+    values = var.unmanaged_private_subnet_names	# can be patterns
+  }
+}
+
+data aws_subnet unmanaged_public {
+   for_each = data.aws_subnet_ids.unmanaged_public.ids != null ? data.aws_subnet_ids.unmanaged_public.ids : toset([])
+   id       = each.value
+}
+
+data aws_subnet unmanaged_private {
+   for_each = data.aws_subnet_ids.unmanaged_private.ids != null ? data.aws_subnet_ids.unmanaged_private.ids : toset([])
+   id       = each.value
+}
+

--- a/vpc/jmiller-hub.tfvars
+++ b/vpc/jmiller-hub.tfvars
@@ -1,0 +1,51 @@
+# Put your cluster where your data is
+region = "us-east-1"
+
+map_users = []
+
+# See https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html for
+# more information
+map_roles = [{
+    rolearn  = "arn:aws:sts::328656936502:assumed-role/jupyterhub-deploy/i-02b0add7d3b133877"
+    username = "jmiller"
+    groups   = ["system:masters"]
+},{
+    rolearn  = "arn:aws:sts::328656936502:role/jupyterhub-deploy/i-02b0add7d3b133877"
+    username = "jmiller"
+    groups   = ["system:masters"]
+}]
+
+# Name of your cluster
+cluster_name = "jmiller-hub"
+
+# # ============================================================================================================
+
+# # Configured for unmanaged private subnets created by IT
+
+# use_private_subnets = true
+# create_vpc = false
+
+# vpc_cidr = "10.128.0.0/9"                        # managed or unmanaged for EKS and EFS.  single block only
+
+# unmanaged_vpc_id = "vpc-0609d0f2a72ccf96d"       # sandbox 
+# unmanaged_private_subnet_names = ["*Private*"]   # or e.g. "*DMZ*", can be patterns or literal
+
+# # cluster_create_security_group = false
+# # cluster_security_group_id = "sg-0534a0b113cbd8501"                    # EKS cluster-to-cluster
+# worker_create_security_group = false
+# worker_additional_security_group_ids = ["sg-0a5f153ac7a17d80c"]       # Access to cluster, plugs into cluster_security_group_id
+# worker_security_group_id = "sg-0a42f0a8c84e73579"                     #
+
+
+# ============================================================================================================
+
+# Configured for managed private subnets created by Terraform
+
+use_private_subnets = true
+create_vpc = true
+
+vpc_cidr = "172.16.0.0/16"
+
+public_subnets =  ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+private_subnets = ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+

--- a/vpc/jmiller-hub.tfvars
+++ b/vpc/jmiller-hub.tfvars
@@ -1,22 +1,10 @@
 # Put your cluster where your data is
 region = "us-east-1"
 
-map_users = []
-
-# See https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html for
-# more information
-map_roles = [{
-    rolearn  = "arn:aws:sts::328656936502:assumed-role/jupyterhub-deploy/i-02b0add7d3b133877"
-    username = "jmiller"
-    groups   = ["system:masters"]
-},{
-    rolearn  = "arn:aws:sts::328656936502:role/jupyterhub-deploy/i-02b0add7d3b133877"
-    username = "jmiller"
-    groups   = ["system:masters"]
-}]
-
 # Name of your cluster
 cluster_name = "jmiller-hub"
+
+allowed_roles = ["arn:aws:iam::328656936502:role/jupyterhub-deploy"]
 
 # # ============================================================================================================
 

--- a/vpc/local.tf
+++ b/vpc/local.tf
@@ -1,0 +1,34 @@
+locals {
+
+       # ====================================================================================
+       # Networking:  (managed, unmanaged vpc) x (public, private subnets)
+       # ====================================================================================
+
+       vpc_id = var.create_vpc ? lookup(module.vpc, "vpc_id") : var.unmanaged_vpc_id 
+
+       vpc_name = var.create_vpc ? lookup(module.vpc, "name") : local.unmanaged_vpc_name
+
+       eks_subnet_ids = var.create_vpc ? local.managed_subnet_ids : local.unmanaged_subnet_ids
+
+       managed_subnet_ids = var.use_private_subnets ? module.vpc.private_subnets : module.vpc.public_subnets
+
+       private_subnet_ids = var.create_vpc ? module.vpc.private_subnets : local.unmanaged_private_subnet_ids
+
+       public_subnet_ids =  var.create_vpc ? module.vpc.public_subnets : local.unmanaged_public_subnet_ids
+
+       unmanaged_vpc_name = data.aws_vpc.unmanaged[*] != [] ? data.aws_vpc.unmanaged[0].tags["Name"] : "UNDEFINED-vpc-name"
+
+       unmanaged_subnet_ids = var.use_private_subnets ? local.unmanaged_private_subnet_ids : local.unmanaged_public_subnet_ids
+       
+       unmanaged_public_subnet_ids = tolist((data.aws_subnet_ids.unmanaged_public[*].ids)[0])
+
+       unmanaged_private_subnet_ids = tolist((data.aws_subnet_ids.unmanaged_private[*].ids)[0])
+
+       private_subnet_cidrs  = var.create_vpc ? module.vpc.private_subnets : local.unmanaged_private_subnet_cidrs
+       public_subnet_cidrs  = var.create_vpc ? module.vpc.public_subnets : local.unmanaged_public_subnet_cidrs
+       unmanaged_private_subnet_cidrs = [for s in data.aws_subnet.unmanaged_private : s.cidr_block]
+       unmanaged_public_subnet_cidrs = [for s in data.aws_subnet.unmanaged_public : s.cidr_block]
+       unmanaged_private_subnet_names = [for s in data.aws_subnet.unmanaged_private : s.tags["Name"]]
+       unmanaged_public_subnet_names = [for s in data.aws_subnet.unmanaged_public : s.tags["Name"]]
+
+}

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 0.12.6"
+}
+
+provider "aws" {
+  version = ">= 2.28.1"
+  region  = "us-east-1"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+data aws_availability_zones available {}
+

--- a/vpc/outputs-2.tf
+++ b/vpc/outputs-2.tf
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------
+
+output unmanaged_vpc_id {
+       value = var.unmanaged_vpc_id
+}
+
+output vpc_cidr {
+       value = var.vpc_cidr
+}
+
+output unmanaged_vpc_name {
+       value = local.unmanaged_vpc_name
+}
+
+output eks_subnet_ids {
+       value = local.eks_subnet_ids
+}
+
+output unmanaged_public_subnet_ids {
+       value = local.unmanaged_public_subnet_ids
+}
+
+output unmanaged_private_subnet_ids {
+       value = local.unmanaged_private_subnet_ids
+}
+
+output public_subnet_cidrs {
+  value = local.public_subnet_cidrs
+}
+
+output unmanaged_public_subnet_names {
+  value = local.unmanaged_public_subnet_names
+}
+
+output private_subnet_cidrs {
+  value = local.private_subnet_cidrs
+}
+
+output unmanaged_private_subnet_names {
+  value = local.unmanaged_private_subnet_names
+}
+
+output worker_create_security_group {
+  value = var.worker_create_security_group
+}
+
+output worker_security_group_id {
+  value = var.worker_security_group_id
+}
+
+

--- a/vpc/security-groups.tf
+++ b/vpc/security-groups.tf
@@ -1,0 +1,104 @@
+resource aws_security_group eks_cluster {
+  name        = "${var.cluster_name}-eks-cluster-sg"
+  description = "Allows communitation with EKS cluster"
+  vpc_id      = local.vpc_id
+  revoke_rules_on_delete = true
+
+  ingress {
+    description = "EKS cluster communication with self"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-eks-cluster-sg"
+  }
+}
+
+# ----------------------------------------------------------------------------
+
+resource aws_security_group eks_worker_additional {
+  name        = "${var.cluster_name}-eks-worker-additional-sg"
+  description = "Allows communitation from worker security group"
+  vpc_id      = local.vpc_id
+  revoke_rules_on_delete = true
+
+  ingress {
+    description = "Ingress from workers on 443"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    security_groups = [aws_security_group.eks_worker_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-eks-worker-additional-sg"
+  }
+}
+
+# ----------------------------------------------------------------------------
+
+
+resource aws_security_group eks_worker_sg {
+  name        = "${var.cluster_name}-eks-worker-sg"
+  description = "Defines workers, worker-to-worker, worker-to-additional-sg"
+  vpc_id      = local.vpc_id
+  revoke_rules_on_delete = true
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-eks-worker-sg"
+  }
+}
+
+resource aws_security_group_rule eks_worker_additional_self_rule {
+  description = "Opens all ports for worker-to-worker"
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  self = true
+  security_group_id = aws_security_group.eks_worker_sg.id
+}
+
+resource aws_security_group_rule eks_worker_additional_https_rule {
+  description = "Opens 443 on worker nodes."
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  source_security_group_id = aws_security_group.eks_worker_additional.id
+  security_group_id = aws_security_group.eks_worker_sg.id
+}
+
+resource aws_security_group_rule eks_worker_additional_high_rule {
+  description = "Opens high ports on worker nodes."
+  type              = "ingress"
+  from_port         = 1025
+  to_port           = 65535
+  protocol          = "tcp"
+  source_security_group_id = aws_security_group.eks_worker_additional.id
+  security_group_id = aws_security_group.eks_worker_sg.id
+}

--- a/vpc/terraform.tfvars
+++ b/vpc/terraform.tfvars
@@ -1,0 +1,1 @@
+jmiller-hub.tfvars

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -109,7 +109,7 @@ variable worker_security_group_id {
 variable worker_additional_security_group_ids {
    description = "Security group accepting 443 ingress from worker_security_group_id"
    type = list(string)
-   default = []
+   default = null
 }
 
 # ========================================================================

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,0 +1,132 @@
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "cluster_name" {
+  default = "test-cluster-change-name"
+}
+
+variable "map_accounts" {
+  description = "Additional AWS account numbers to add to the aws-auth configmap."
+  type        = list(string)
+  default = [ ]
+}
+
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+
+  default = [
+  ]
+}
+
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+
+  default = [
+  ]
+}
+
+# -------------------------------------------------------------------------
+#                     Networking config 
+
+# ========================================================================
+# Always define
+
+variable create_vpc {
+    description = "When true,  Terraform creates VPC, subnet, etc. resources"
+    type = bool
+    default = false   #  XXXX true
+}
+
+variable use_private_subnets {
+    description = "Use private subnets for EKS worker nodes."
+    type        = bool
+    default = true   # XXXX false
+}
+
+variable vpc_cidr {
+    description = "IP range of subnets"
+    type = string
+    default = "172.16.0.0/16"
+}
+
+# ========================================================================
+# Define when create_vpc is false (i.e. for unmanaged (externally created)
+# vpc and subnets.
+
+variable unmanaged_vpc_id {
+   description = "ID of unmanaged VPC, e.g. created by IT department."
+   type = string
+   default = ""
+}
+
+variable unmanaged_public_subnet_names {
+   description = "Pattern applied to Name tag to select unmanaged public subnets from the unmanaged vpc"
+   type = list(string)
+   default = ["*Public*"]
+}
+
+variable unmanaged_private_subnet_names {
+   description = "Patterns applied to Name tag to select unmanaged private subnets from the unmanaged vpc"
+   type = list(string)
+   default = ["*Private*"]
+}
+
+variable cluster_create_security_group {
+   description = "If true,  EKS module should create security group for group-to-cluster accesss."
+   type = bool
+   default = true
+}
+
+variable cluster_security_group_id {
+   description = "ID of security group for EKS cluster self-trust."
+   type = string
+   default = null
+}
+
+variable worker_create_security_group {
+   description = "If true,  EKS module should create security group for accessing EKS endpoint for private workers and CI-nodes."
+   type = bool
+   default = true
+}
+
+variable worker_security_group_id {
+   description = "ID of security group to which EKS worker and terraform deployment nodes will be assigned."
+   type = string
+   default = null
+}
+
+variable worker_additional_security_group_ids {
+   description = "Security group accepting 443 ingress from worker_security_group_id"
+   type = list(string)
+   default = []
+}
+
+# ========================================================================
+# Define when create_vpc is true (i.e. for managed vpc and subnets)
+
+variable public_subnets {  
+    description = "Public subnet IP ranges."
+    type        = list(string)
+    default = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+}
+
+variable private_subnets {  
+    description = "Private subnet IP ranges."
+    type        = list(string)
+    default = []   #   ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+}
+
+variable allowed_roles {
+    default = []
+}

--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -1,0 +1,73 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.6"
+
+  create_vpc = var.create_vpc
+
+  name                 = "${var.cluster_name}-vpc"
+  cidr                 = var.vpc_cidr
+  azs                  = data.aws_availability_zones.available.names
+
+  # We can use private subnets too once https://github.com/aws/containers-roadmap/issues/607
+  # is fixed
+  public_subnets       = var.public_subnets
+  private_subnets      = var.private_subnets
+  
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  enable_nat_gateway   = var.use_private_subnets
+  single_nat_gateway   = var.use_private_subnets
+  
+  tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+}
+
+
+# =======================================================================
+
+data aws_vpc unmanaged {
+  count =  var.create_vpc ? 0 : 1
+  id = var.unmanaged_vpc_id
+}
+
+data aws_subnet_ids unmanaged_public {
+  # splat expr for conditional creation
+  vpc_id = var.unmanaged_vpc_id
+
+  filter {
+    name   = "tag:Name"
+    values = var.unmanaged_public_subnet_names         # can be patterns
+  }
+}
+
+data aws_subnet_ids unmanaged_private {
+  # splat expr for conditional creation
+  vpc_id = var.unmanaged_vpc_id
+
+  filter {
+    name   = "tag:Name"
+    values = var.unmanaged_private_subnet_names	# can be patterns
+  }
+}
+
+data aws_subnet unmanaged_public {
+   for_each = data.aws_subnet_ids.unmanaged_public.ids != null ? data.aws_subnet_ids.unmanaged_public.ids : toset([])
+   id       = each.value
+}
+
+data aws_subnet unmanaged_private {
+   for_each = data.aws_subnet_ids.unmanaged_private.ids != null ? data.aws_subnet_ids.unmanaged_private.ids : toset([])
+   id       = each.value
+}
+


### PR DESCRIPTION
PR'ing for easier comments and review by Octarine,  currently stalling out in "aws" terraform here:

module.eks.module.node_groups.aws_eks_node_group.workers["core"]: Still creating... [20m20s elapsed]
module.eks.module.node_groups.aws_eks_node_group.workers["notebook"]: Still creating... [20m20s elapsed]

Does the following:

1. Adds variables to support:

     (managed vpc,  unmanaged vpc) x (public subnets, private subnets) x  (managed security groups, unmanaged)

2. Adds a script to "aws",  mktags,  for tagging ITSD created resources to meet EKS requirements.

3. Adds a "vpc" directory parallel to "aws" which helps debug config variables and show VPC resource discovery results based on high level config variables.  It also creates cluster and worker security groups unconditionally.

4. Has tfvars which are hard-wired for the jmiller-hub prototype and illustrate managed and unmanaged private configurations.

5. Attempts to maintain backward compatibility for possible push upstream  to pangeo-data.   Attempting to do this adds complexity so it may be time to cut direct ties to pangeo and truly fork with "what  we  need  to do."

Unmanaged security groups which we create were added to enable giving cluster access perms to our CI-nodes so that a null resource check works once the cluster is built.   This appears to be working but precedes node group creation which isn't.