### PR TITLE
Get rid of hubploy_deployer role and policies

### DIFF
--- a/aws-creds/iam.tf
+++ b/aws-creds/iam.tf
@@ -101,7 +101,7 @@ resource "aws_iam_role" "terraform_architect_iam_role" {
   tags = {
     "Terraform" = "True"
   }
-  permissions_boundary = "arn:aws:iam::328656936502:policy/TestRoleCreationBoundary"
+  #permissions_boundary = "arn:aws:iam::328656936502:policy/TestRoleCreationBoundary"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_iam"{

--- a/aws-creds/iam.tf
+++ b/aws-creds/iam.tf
@@ -10,6 +10,11 @@ terraform {
 provider "aws" {
   version = ">= 2.28.1"
   region  = var.region
+#    assume_role {
+#      role_arn     = "arn:aws:iam::328656936502:role/jupyterhub-deploy2"
+#      session_name = "SESSION_NAME"
+#      external_id  = "EXTERNAL_ID"
+#  }
 }
 
 variable "region" {
@@ -93,6 +98,10 @@ resource "aws_iam_role" "terraform_architect_iam_role" {
   name = "${var.iam_prefix}terraform-architect"
   path = "/"
   assume_role_policy = data.aws_iam_policy_document.terraform_user_assume_policy.json
+  tags = {
+    "Terraform" = "True"
+  }
+  permissions_boundary = "arn:aws:iam::328656936502:policy/TestRoleCreationBoundary"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_iam"{

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -1,18 +1,3 @@
-# Attached to deployers group to let them assume the role we need
-# Attached to hubploy-deployer role as well
-data "aws_iam_policy_document" "hubploy_deployers" {
-  statement {
-    sid = "1"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    resources = [
-        aws_iam_role.hubploy_eks.arn,
-        aws_iam_role.hubploy_ecr.arn
-    ]
-  }
-}
-
 # Attached to group
 data "aws_iam_policy_document" "hubploy_eks" {
     statement {
@@ -57,19 +42,6 @@ resource "aws_iam_role_policy_attachment" "hubploy_eks" {
   policy_arn = aws_iam_policy.hubploy_eks.arn
 }
 
-resource "aws_iam_policy" "hubploy_deployers" {
-  name = "${var.cluster_name}-hubploy-deployers"
-
-  policy = data.aws_iam_policy_document.hubploy_deployers.json
-}
-resource "aws_iam_group" "hubploy_deployers" {
-    name = "${var.cluster_name}-hubploy-deployers"
-}
-resource "aws_iam_group_policy_attachment" "hubploy_deployers" {
-  group       = aws_iam_group.hubploy_deployers.name
-  policy_arn = aws_iam_policy.hubploy_deployers.arn
-}
-
 resource "aws_iam_role" "hubploy_ecr" {
   name = "${var.cluster_name}-hubploy-ecr"
   assume_role_policy = data.aws_iam_policy_document.hubploy_assumptions.json
@@ -79,35 +51,4 @@ resource "aws_iam_role_policy_attachment" "hubploy_ecr_policy_attachment" {
   role = aws_iam_role.hubploy_ecr.name
   # FIXME: Restrict resources to the ECR repository we created
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
-}
-
-
-data "aws_iam_policy_document" "hubploy_deployer_ec2_policy" {
-  statement {
-    sid = "1"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    principals {
-        type = "Service"
-        identifiers = [
-            "ec2.amazonaws.com"
-        ]
-    }
-  }
-}
-
-resource "aws_iam_role" "hubploy_deployer" {
-  name = "${var.cluster_name}-hubploy-deployer"
-  assume_role_policy = data.aws_iam_policy_document.hubploy_deployer_ec2_policy.json
-}
-
-resource "aws_iam_policy" "hubploy_deployer" {
-  name = "${var.cluster_name}-hubploy-deployer"
-  policy = data.aws_iam_policy_document.hubploy_deployers.json
-}
-
-resource "aws_iam_role_policy_attachment" "hubploy_deployer" {
-  role       = aws_iam_role.hubploy_deployer.name
-  policy_arn = aws_iam_policy.hubploy_deployer.arn
 }


### PR DESCRIPTION
We don't have users anymore, so we don't need these.  With permission boundaries in effect, having these in the TF code will cause the deployment to fail.