### PR TITLE
Private eks api only

### DIFF
--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -6,12 +6,12 @@ resource "aws_efs_file_system" "home_dirs" {
 
 
 resource "aws_security_group" "home_dirs_sg" {
-  name   = "home_dirs_sg"
-  vpc_id = module.vpc.vpc_id
+  name   = "${var.cluster_name}-home_dirs_sg"
+  vpc_id = local.vpc_id
 
   # NFS
   ingress {
-    cidr_blocks = [ var.cidr ]
+    cidr_blocks = [ var.vpc_cidr ]
     # FIXME: Do we need this security_groups here along with cidr_blocks
     security_groups = [ module.eks.worker_security_group_id ]
     from_port        = 2049
@@ -20,10 +20,12 @@ resource "aws_security_group" "home_dirs_sg" {
   }
 }
 
+
+# XXXX should the EFS subnets be public or private?
 resource "aws_efs_mount_target" "home_dirs_targets" {
-  count = length(module.vpc.public_subnets)
+  count = length(local.private_subnet_ids)
   file_system_id = aws_efs_file_system.home_dirs.id
-  subnet_id = module.vpc.public_subnets[count.index]
+  subnet_id = local.private_subnet_ids[count.index]
   security_groups = [ aws_security_group.home_dirs_sg.id ]
 }
 
@@ -39,7 +41,7 @@ resource "kubernetes_namespace" "support" {
 }
 
 resource "helm_release" "efs-provisioner" {
-  name = "efs-provisioner"
+  name = "${var.cluster_name}-efs-provisioner"
   namespace = kubernetes_namespace.support.metadata.0.name
   repository = data.helm_repository.stable.metadata[0].name
   chart = "efs-provisioner"
@@ -73,3 +75,4 @@ resource "helm_release" "efs-provisioner" {
     value = "aws.amazon.com/efs"
   }
 }
+

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -11,6 +11,7 @@ resource "aws_security_group" "home_dirs_sg" {
 
   # NFS
   ingress {
+    cidr_blocks = local.private_subnet_cidrs
     security_groups = [ module.eks.worker_security_group_id ]
     from_port        = 2049
     to_port          = 2049

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -11,8 +11,6 @@ resource "aws_security_group" "home_dirs_sg" {
 
   # NFS
   ingress {
-    cidr_blocks = [ var.vpc_cidr ]
-    # FIXME: Do we need this security_groups here along with cidr_blocks
     security_groups = [ module.eks.worker_security_group_id ]
     from_port        = 2049
     to_port          = 2049

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -1,3 +1,18 @@
+# Attached to deployers group to let them assume the role we need
+# Attached to hubploy-deployer role as well
+data "aws_iam_policy_document" "hubploy_deployers" {
+  statement {
+    sid = "1"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = [
+        aws_iam_role.hubploy_eks.arn,
+        aws_iam_role.hubploy_ecr.arn
+    ]
+  }
+}
+
 # Attached to group
 data "aws_iam_policy_document" "hubploy_eks" {
     statement {
@@ -42,6 +57,19 @@ resource "aws_iam_role_policy_attachment" "hubploy_eks" {
   policy_arn = aws_iam_policy.hubploy_eks.arn
 }
 
+resource "aws_iam_policy" "hubploy_deployers" {
+  name = "${var.cluster_name}-hubploy-deployers"
+
+  policy = data.aws_iam_policy_document.hubploy_deployers.json
+}
+resource "aws_iam_group" "hubploy_deployers" {
+    name = "${var.cluster_name}-hubploy-deployers"
+}
+resource "aws_iam_group_policy_attachment" "hubploy_deployers" {
+  group       = aws_iam_group.hubploy_deployers.name
+  policy_arn = aws_iam_policy.hubploy_deployers.arn
+}
+
 resource "aws_iam_role" "hubploy_ecr" {
   name = "${var.cluster_name}-hubploy-ecr"
   assume_role_policy = data.aws_iam_policy_document.hubploy_assumptions.json
@@ -51,4 +79,35 @@ resource "aws_iam_role_policy_attachment" "hubploy_ecr_policy_attachment" {
   role = aws_iam_role.hubploy_ecr.name
   # FIXME: Restrict resources to the ECR repository we created
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+
+data "aws_iam_policy_document" "hubploy_deployer_ec2_policy" {
+  statement {
+    sid = "1"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+        type = "Service"
+        identifiers = [
+            "ec2.amazonaws.com"
+        ]
+    }
+  }
+}
+
+resource "aws_iam_role" "hubploy_deployer" {
+  name = "${var.cluster_name}-hubploy-deployer"
+  assume_role_policy = data.aws_iam_policy_document.hubploy_deployer_ec2_policy.json
+}
+
+resource "aws_iam_policy" "hubploy_deployer" {
+  name = "${var.cluster_name}-hubploy-deployer"
+  policy = data.aws_iam_policy_document.hubploy_deployers.json
+}
+
+resource "aws_iam_role_policy_attachment" "hubploy_deployer" {
+  role       = aws_iam_role.hubploy_deployer.name
+  policy_arn = aws_iam_policy.hubploy_deployer.arn
 }

--- a/aws/local.tf
+++ b/aws/local.tf
@@ -7,8 +7,6 @@ locals {
        private_subnet_cidrs = [for s in data.aws_subnet.private : s.cidr_block]
        private_subnet_names = [for s in data.aws_subnet.private : s.tags["Name"]]
 
-       nat_ip_cidrs = [ for nat in data.aws_nat_gateway.nat_gateways : join("", [nat.public_ip, "/32"]) ]
-       cluster_endpoint_public_access_cidrs = concat(local.nat_ip_cidrs, var.cluster_endpoint_public_access_extra_cidrs)
        vpc_id = data.aws_vpc.unmanaged[0].id
 
        cluster_sg_id = data.aws_security_group.cluster_sg.id

--- a/aws/local.tf
+++ b/aws/local.tf
@@ -1,0 +1,13 @@
+locals {
+       public_subnet_ids = tolist((data.aws_subnet_ids.public[*].ids)[0])
+       public_subnet_cidrs = [for s in data.aws_subnet.public : s.cidr_block]
+       public_subnet_names = [for s in data.aws_subnet.public : s.tags["Name"]]
+
+       private_subnet_ids = tolist((data.aws_subnet_ids.private[*].ids)[0])
+       private_subnet_cidrs = [for s in data.aws_subnet.private : s.cidr_block]
+       private_subnet_names = [for s in data.aws_subnet.private : s.tags["Name"]]
+
+       nat_ip_cidrs = [ for nat in data.aws_nat_gateway.nat_gateways : join("", [nat.public_ip, "/32"]) ]
+       cluster_endpoint_public_access_cidrs = concat(local.nat_ip_cidrs, var.cluster_endpoint_public_access_extra_cidrs)
+       vpc_id = data.aws_vpc.unmanaged[0].id
+}

--- a/aws/local.tf
+++ b/aws/local.tf
@@ -8,7 +8,4 @@ locals {
        private_subnet_names = [for s in data.aws_subnet.private : s.tags["Name"]]
 
        vpc_id = data.aws_vpc.unmanaged[0].id
-
-       cluster_sg_id = data.aws_security_group.cluster_sg.id
-       worker_sg_id = data.aws_security_group.worker_sg.id
 }

--- a/aws/local.tf
+++ b/aws/local.tf
@@ -10,4 +10,7 @@ locals {
        nat_ip_cidrs = [ for nat in data.aws_nat_gateway.nat_gateways : join("", [nat.public_ip, "/32"]) ]
        cluster_endpoint_public_access_cidrs = concat(local.nat_ip_cidrs, var.cluster_endpoint_public_access_extra_cidrs)
        vpc_id = data.aws_vpc.unmanaged[0].id
+
+       cluster_sg_id = data.aws_security_group.cluster_sg.id
+       worker_sg_id = data.aws_security_group.worker_sg.id
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -43,10 +43,10 @@ module "eks" {
 
   # Sets additional worker security groups on console.
   cluster_create_security_group = false
-  cluster_security_group_id = local.cluster_sg_id
+  cluster_security_group_id = data.aws_security_group.cluster_sg.id
 
   worker_create_security_group = false
-  worker_security_group_id = local.worker_sg_id
+  worker_security_group_id = data.aws_security_group.worker_sg.id
   
   vpc_id       = local.vpc_id
   enable_irsa  = true

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -41,6 +41,7 @@ module "eks" {
   cluster_endpoint_public_access = false
   cluster_endpoint_private_access = true
 
+  # Sets additional worker security groups on console.
   cluster_create_security_group = false
   cluster_security_group_id = local.cluster_sg_id
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -35,10 +35,18 @@ data "aws_availability_zones" "available" {
 module "eks" {
   source       = "terraform-aws-modules/eks/aws"
   cluster_name = var.cluster_name
+
   subnets      = local.private_subnet_ids
-  cluster_endpoint_public_access = true
-  cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
-  cluster_endpoint_private_access = false
+
+  cluster_endpoint_public_access = false
+  cluster_endpoint_private_access = true
+
+  cluster_create_security_group = false
+  cluster_security_group_id = local.cluster_sg_id
+
+  worker_create_security_group = false
+  worker_security_group_id = local.worker_sg_id
+  
   vpc_id       = local.vpc_id
   enable_irsa  = true
   

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -32,47 +32,16 @@ provider "kubernetes" {
 data "aws_availability_zones" "available" {
 }
 
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.6"
-
-  name                 = "${var.cluster_name}-vpc"
-  cidr                 = var.cidr
-  azs                  = data.aws_availability_zones.available.names
-  # We can use private subnets too once https://github.com/aws/containers-roadmap/issues/607
-  # is fixed
-  public_subnets       = var.public_subnets
-  private_subnets      = var.private_subnets
-  
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  enable_nat_gateway   = var.use_private_subnets
-  single_nat_gateway   = var.use_private_subnets
-  
-  tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
-  }
-
-  public_subnet_tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
-    "kubernetes.io/role/elb"                    = "1"
-  }
-
-  private_subnet_tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
-    "kubernetes.io/role/internal-elb"           = "1"
-  }
-}
-
 module "eks" {
   source       = "terraform-aws-modules/eks/aws"
   cluster_name = var.cluster_name
-  subnets      = var.use_private_subnets ? module.vpc.private_subnets : module.vpc.public_subnets
-  cluster_endpoint_private_access = true
-  vpc_id       = module.vpc.vpc_id
+  subnets      = local.private_subnet_ids
+  cluster_endpoint_public_access = true
+  cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
+  cluster_endpoint_private_access = false
+  vpc_id       = local.vpc_id
   enable_irsa  = true
-
-
+  
   node_groups_defaults = {
     ami_type  = "AL2_x86_64"
     disk_size = 50
@@ -105,8 +74,8 @@ module "eks" {
     }
   }
 
-
   map_accounts = var.map_accounts
+  map_users = var.map_users
 
   map_roles = concat([{
     rolearn  = aws_iam_role.hubploy_eks.arn
@@ -114,6 +83,7 @@ module "eks" {
     # FIXME: Narrow these permissions down?
     groups   = ["system:masters"]
   }], var.map_roles)
+
 }
 
 

--- a/aws/mktags
+++ b/aws/mktags
@@ -1,0 +1,19 @@
+#! /bin/bash  -x 
+
+cluster_name="jmiller-hub"
+vpc_id="vpc-0609d0f2a72ccf96d"
+public_subnet_ids="subnet-0e5478d300d15a00c subnet-0acbd0e839b582822 subnet-0980788a037ffd5d7"
+dmz_subnet_ids="subnet-0c19c68596b826f92 subnet-01458be8f15059eee subnet-0946b77db4de4d579"
+private_subnet_ids="subnet-061c51be9ee131e6d subnet-0f049f5e66619aef4 subnet-0e0f36a4570f01b55"
+
+aws ec2 create-tags --resources $vpc_id --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"  
+
+aws ec2 create-tags --resources $public_subnet_ids   --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared" 
+aws ec2 create-tags --resources $public_subnet_ids   --tags "Key=kubernetes.io/role/elb,Value=1"
+
+aws ec2 create-tags --resources $dmz_subnet_ids     --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"
+aws ec2 create-tags --resources $dmz_subnet_ids     --tags "Key=kubernetes.io/role/internal-elb,Value=1"
+
+aws ec2 create-tags --resources $private_subnet_ids --tags "Key=kubernetes.io/cluster/${cluster_name},Value=shared"
+aws ec2 create-tags --resources $private_subnet_ids --tags "Key=kubernetes.io/role/internal-elb,Value=1"
+

--- a/aws/outputs-2.tf
+++ b/aws/outputs-2.tf
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------
+
+output vpc_id {
+       value = local.vpc_id
+}
+
+output vpc_cidr {
+       value = var.vpc_cidr
+}
+
+output vpc_name {
+       value = var.vpc_name
+}
+
+output public_subnet_ids {
+       value = local.public_subnet_ids
+}
+output public_subnet_cidrs {
+  value = local.public_subnet_cidrs
+}
+output public_subnet_names {
+  value = local.public_subnet_names
+}
+
+output private_subnet_ids {
+       value = local.private_subnet_ids
+}
+output private_subnet_cidrs {
+  value = local.private_subnet_cidrs
+}
+output private_subnet_names {
+  value = local.private_subnet_names
+}
+
+output nat_cidrs {
+  value = local.nat_ip_cidrs
+}
+
+output cluster_endpoint_public_access_cidrs {
+  value = local.cluster_endpoint_public_access_cidrs
+}

--- a/aws/outputs-2.tf
+++ b/aws/outputs-2.tf
@@ -4,10 +4,6 @@ output vpc_id {
        value = local.vpc_id
 }
 
-output vpc_cidr {
-       value = var.vpc_cidr
-}
-
 output vpc_name {
        value = var.vpc_name
 }
@@ -32,10 +28,3 @@ output private_subnet_names {
   value = local.private_subnet_names
 }
 
-output nat_cidrs {
-  value = local.nat_ip_cidrs
-}
-
-output cluster_endpoint_public_access_cidrs {
-  value = local.cluster_endpoint_public_access_cidrs
-}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -24,30 +24,55 @@ variable "map_roles" {
   ]
 }
 
-variable "use_private_subnets" {
-    description = "Use private subnets for EKS worker nodes."
-    type        = bool
-    default = false
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+
+  default = [
+  ]
 }
 
-variable "public_subnets" {  
-    description = "Public subnet IP ranges."
-    type        = list(string)
-    default = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
-}
+# -------------------------------------------------------------------------
+#                     Networking config 
 
-variable "private_subnets" {  
-    description = "Private subnet IP ranges."
-    type        = list(string)
-    default = []   #   ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
-}
+# ========================================================================
+# Always define
 
-variable "cidr" {
+variable vpc_cidr {
     description = "IP range of subnets"
     type = string
-    default = "172.16.0.0/16"
+    # default = "172.16.0.0/16"
 }
 
-variable "allowed_roles" {
+variable vpc_name {
+   description = "Name of unmanaged VPC, e.g. created by IT department."
+   type = string
+}
+
+variable private_subnet_names {
+   description = "Patterns applied to Name tag to select unmanaged private subnets from the unmanaged vpc"
+   type = list(string)
+   default = ["*Private*"]
+}
+
+variable public_subnet_names {
+   description = "Patterns applied to Name tag to select unmanaged public subnets from the unmanaged vpc"
+   type = list(string)
+   default = ["*Public*"]
+}
+
+variable cluster_endpoint_public_access_extra_cidrs {
+   description = "Add other CIDRs for EKS API public endpoint access in addition to private subnet NAT EIPs."
+   type = list(string)
+   default = [ ]
+}
+
+
+# ========================================================================
+variable allowed_roles {
     default = []
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -39,12 +39,6 @@ variable "map_users" {
 # -------------------------------------------------------------------------
 #                     Networking config 
 
-variable vpc_cidr {
-    description = "IP range of subnets"
-    type = string
-    # default = "172.16.0.0/16"
-}
-
 variable vpc_name {
    description = "Name of unmanaged VPC, e.g. created by IT department."
    type = string
@@ -60,12 +54,6 @@ variable public_subnet_names {
    description = "Patterns applied to Name tag to select unmanaged public subnets from the unmanaged vpc"
    type = list(string)
    default = ["*Public*"]
-}
-
-variable cluster_endpoint_public_access_extra_cidrs {
-   description = "Add other CIDRs for EKS API public endpoint access in addition to private subnet NAT EIPs."
-   type = list(string)
-   default = [ ]
 }
 
 variable cluster_sg_name {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -39,9 +39,6 @@ variable "map_users" {
 # -------------------------------------------------------------------------
 #                     Networking config 
 
-# ========================================================================
-# Always define
-
 variable vpc_cidr {
     description = "IP range of subnets"
     type = string
@@ -71,6 +68,15 @@ variable cluster_endpoint_public_access_extra_cidrs {
    default = [ ]
 }
 
+variable cluster_sg_name {
+   description = "Group added to EKS cluster granting access to API endpoint 443 to members of worker sg."
+   type = string
+}
+
+variable worker_sg_name {
+   description = "Group added to unmanaged workers.  Gives workers access to cluster 443 via the above, cluster access to workers, workers to workers."
+   type = string
+}
 
 # ========================================================================
 variable allowed_roles {

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -39,3 +39,17 @@ data aws_subnet public {
    id       = each.value
 }
 
+data aws_security_group cluster_sg {
+  filter {
+    name   = "tag:Name"
+    values = [var.cluster_sg_name]
+  }
+}
+
+data aws_security_group worker_sg {
+  filter {
+    name   = "tag:Name"
+    values = [var.worker_sg_name]
+  }
+}
+

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -1,0 +1,41 @@
+# =======================================================================
+
+data aws_vpc unmanaged {
+  count =  1
+  filter {
+    name   = "tag:Name"
+    values = [var.vpc_name]	# can be patterns
+  }
+}
+
+data aws_nat_gateway nat_gateways {
+   count = length(local.public_subnet_ids)
+   subnet_id = local.public_subnet_ids[count.index]
+}
+
+data aws_subnet_ids private {
+  vpc_id = local.vpc_id
+  filter {
+    name   = "tag:Name"
+    values = var.private_subnet_names	# can be patterns
+  }
+}
+
+data aws_subnet private {
+   for_each = data.aws_subnet_ids.private.ids
+   id       = each.value
+}
+
+data aws_subnet_ids public {
+  vpc_id = local.vpc_id
+  filter {
+    name   = "tag:Name"
+    values = var.public_subnet_names	# can be patterns
+  }
+}
+
+data aws_subnet public {
+   for_each = data.aws_subnet_ids.public.ids
+   id       = each.value
+}
+

--- a/aws/your-cluster.tfvars.template
+++ b/aws/your-cluster.tfvars.template
@@ -1,7 +1,22 @@
+
 # Put your cluster where your data is
 region = "us-east-1"
 
 # Name of your cluster
-cluster_name = "<cluster-name>"
+cluster_name = "<YOUR-HUB>"   # jmiller-hub"
 
-allowed_roles = ["arn:aws:iam::<account-id>:role/jupyterhub-deploy"]
+allowed_roles = ["<DEPLOY-ROLE>"]   
+
+# # ============================================================================================================
+
+# # Configured for unmanaged private subnets created by IT
+vpc_cidr = "<VPC-CIDR>"   #  "10.144.0.0/12"   # managed or unmanaged for EKS and EFS.  single block only
+
+vpc_name = "<VPC-NAME>"   # "DEV-WF-SC-SB"
+
+public_subnet_names = ["<PUBLIC-SUBNET-NAMES-OR-PATTERNS>"]  # ["DEV-WF-SC-SB-Public-*"]
+
+private_subnet_names = ["<PRIVATE-SUBNET-NAMES-OR-PATTERNS>"]  # ["DEV-WF-SC-SB-DMZ-*"]
+
+cluster_endpoint_public_access_extra_cidrs = []  # Public EKS API endpoint only reachable by NATs and these.
+

--- a/aws/your-cluster.tfvars.template
+++ b/aws/your-cluster.tfvars.template
@@ -20,3 +20,6 @@ private_subnet_names = ["<PRIVATE-SUBNET-NAMES-OR-PATTERNS>"]  # ["DEV-WF-SC-SB-
 
 cluster_endpoint_public_access_extra_cidrs = []  # Public EKS API endpoint only reachable by NATs and these.
 
+cluster_sg_name = ""  # "jmiller-cluster-sg" modeled after Additional worker sgs first group
+worker_sg_name = ""   # "jmiller-worker-sg" modeled after Additional worker sg source group for first group
+

--- a/aws/your-cluster.tfvars.template
+++ b/aws/your-cluster.tfvars.template
@@ -10,7 +10,6 @@ allowed_roles = ["<DEPLOY-ROLE>"]
 # # ============================================================================================================
 
 # # Configured for unmanaged private subnets created by IT
-vpc_cidr = "<VPC-CIDR>"   #  "10.144.0.0/12"   # managed or unmanaged for EKS and EFS.  single block only
 
 vpc_name = "<VPC-NAME>"   # "DEV-WF-SC-SB"
 
@@ -18,8 +17,6 @@ public_subnet_names = ["<PUBLIC-SUBNET-NAMES-OR-PATTERNS>"]  # ["DEV-WF-SC-SB-Pu
 
 private_subnet_names = ["<PRIVATE-SUBNET-NAMES-OR-PATTERNS>"]  # ["DEV-WF-SC-SB-DMZ-*"]
 
-cluster_endpoint_public_access_extra_cidrs = []  # Public EKS API endpoint only reachable by NATs and these.
-
-cluster_sg_name = ""  # "jmiller-cluster-sg" modeled after Additional worker sgs first group
-worker_sg_name = ""   # "jmiller-worker-sg" modeled after Additional worker sg source group for first group
+cluster_sg_name = ""  # "jmiller-cluster-sg" modeled after Additional worker sg
+worker_sg_name = ""   # "jmiller-worker-sg" modeled after Additional worker sg source group
 


### PR DESCRIPTION
Switches from public-only to private-only EKS API  endpoint because preferred ITSD configuration will not include NATs or predictable/narrowly-defined public IPs for elastic firewall NAT replacement scheme.
Drops vpc_cidr  defined for EFS in favor of local.private_subnet_cidrs since baseline CIDR seemed overly broad and CIDR is no longer constrained to a single block to match VPC CIDR we no longer create.