### PR TITLE
Automatic kubectl config

### DIFF
--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -80,6 +80,7 @@ resource "helm_release" "cluster-autoscaler" {
   repository = data.helm_repository.stable.metadata[0].name
   chart = "cluster-autoscaler"
   version = "7.2.0"
+  depends_on = [null_resource.kubectl_config]
 
   values = [
     file("cluster-autoscaler-values.yml")

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -1,4 +1,5 @@
 resource "aws_efs_file_system" "home_dirs" {
+  depends_on = [null_resource.kubectl_config]
   tags = {
     Name = "${var.cluster_name}-home-dirs"
   }
@@ -75,4 +76,3 @@ resource "helm_release" "efs-provisioner" {
     value = "aws.amazon.com/efs"
   }
 }
-

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -53,7 +53,7 @@ module "eks" {
 
   worker_create_security_group = false
   worker_security_group_id = data.aws_security_group.worker_sg.id
-  
+
   node_groups_defaults = {
     ami_type  = "AL2_x86_64"
     disk_size = 50
@@ -104,5 +104,12 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+resource "null_resource" "kubectl_config" {
+  depends_on = [module.eks]
+  provisioner "local-exec" {
+     command="aws eks update-kubeconfig --name ${var.cluster_name}"
   }
 }


### PR DESCRIPTION
Solves the "terraform twice due too missing kubectl config" by adding a null resource command.

Added depends_on's so that kubectl config is done after module.eks and efs and autoscaler follow kubectl config.