### PR TITLE
Add role to kubeconfig

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -110,6 +110,6 @@ provider "helm" {
 resource "null_resource" "kubectl_config" {
   depends_on = [module.eks]
   provisioner "local-exec" {
-     command="aws eks update-kubeconfig --name ${var.cluster_name}"
+     command="aws eks update-kubeconfig --name ${var.cluster_name} --role-arn ${var.rolearn}"
   }
 }


### PR DESCRIPTION
I added --role-arn for jupyterhub-admin to the kubeconfig command in main.tf which solves the chicken-and-egg problem.   I think it is necessary for successful teardown.  It now basically matches the kubeconfig in jupyterhub-deploy.