### PR TITLE
Make notebook instance type t3.xlarge variable

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -77,7 +77,7 @@ module "eks" {
      max_capacity     = 10
      min_capacity     = 1
 
-     instance_type = "t3.medium"
+     instance_type = var.notebook_instance_type
      k8s_labels = {
        "hub.jupyter.org/node-purpose" =  "user"
      }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -53,7 +53,7 @@ variable "username" {
 
 
 # -------------------------------------------------------------------------
-#                     Networking config 
+#                     Networking config
 
 variable vpc_name {
    description = "Name of unmanaged VPC, e.g. created by IT department."
@@ -83,6 +83,14 @@ variable worker_sg_name {
 }
 
 # ========================================================================
+
+variable notebook_instance_type {
+   description = "EC2 instance type used for notebook sessions."
+   type = string
+   default = "t3.xlarge"
+}
+
+# ========================================================================
 variable allowed_roles {
     default = []
 }
@@ -92,4 +100,3 @@ variable cluster_version {
     default = "1.17"
     type = string
 }
-


### PR DESCRIPTION
Makes notebook EC2 instance type a variable defaulting to t3.xlarge so JWST CAL notebook tests for Roman deployment pass.