### PR TITLE
Pluggable roles

### DIFF
--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -9,12 +9,7 @@ module "iam_assumable_role_admin" {
   create_role                   = false
   role_name                     = "${module.eks.cluster_id}-cluster-autoscaler"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
-  role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler-service-account"]
-}
-
-data "aws_iam_policy" "cluster_autoscaler" {
-  name = "${module.eks.cluster_id}-cluster-autoscaler-permissions"
 }
 
 resource "helm_release" "cluster-autoscaler" {

--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -6,91 +6,22 @@ terraform {
 module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.3.0"
-  create_role                   = true
+  create_role                   = false
   role_name                     = "${module.eks.cluster_id}-cluster-autoscaler"
-  role_permissions_boundary_arn = var.permissions_boundary
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler-service-account"]
 }
 
-resource "aws_iam_policy" "cluster_autoscaler" {
-  name_prefix = "cluster-autoscaler"
-  description = "EKS cluster-autoscaler policy for cluster ${module.eks.cluster_id}"
-  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
-}
-
-data "aws_iam_policy_document" "cluster_autoscaler" {
-  statement {
-    sid    = "clusterAutoscalerAll"
-    effect = "Allow"
-
-    actions = [
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:DescribeTags",
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-      "ec2:DescribeLaunchTemplateVersions",
-	]
-
-    resources = ["*"]
-  }
-
-  statement {
-    sid    = "clusterAutoscalerIAM"
-    effect = "Allow"
-
-    actions = [
-      "iam:GetRole",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    sid    = "clusterAutoscalerOwn"
-    effect = "Allow"
-
-    actions = [
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:DescribeTags",
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-      "ec2:DescribeLaunchTemplateVersions",
-   ]	
-
-    resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
-      values   = ["owned"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
-      values   = ["true"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "autoscaler-attach" {
-  role = "${module.eks.cluster_id}-cluster-autoscaler"
-  policy_arn = aws_iam_policy.cluster_autoscaler.arn
+data "aws_iam_policy" "cluster_autoscaler" {
+  name = "${module.eks.cluster_id}-cluster-autoscaler-permissions"
 }
 
 resource "helm_release" "cluster-autoscaler" {
   name = "cluster-autoscaler"
   # Check that this is good, kube-system should already exist
   namespace = "kube-system"
-  repository = "https://charts.helm.sh/stable/" 
+  repository = "https://charts.helm.sh/stable/"
   chart = "cluster-autoscaler"
   version = "7.2.0"
   depends_on = [null_resource.kubectl_config]

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -56,8 +56,8 @@ module "eks" {
 
   manage_cluster_iam_resources = false
   manage_worker_iam_resources = false
-  workers_role_name = join("", [var.cluster_name, "-worker"])
-  cluster_iam_role_name = join("", [var.cluster_name, "-cluster"])
+  workers_role_name = data.aws_iam_role.worker_role.name
+  cluster_iam_role_name = data.aws_iam_role.cluster_role.name
 
   node_groups_defaults = {
     ami_type  = "AL2_x86_64"
@@ -76,6 +76,7 @@ module "eks" {
       }
       additional_tags = {
       }
+      iam_role_arn = data.aws_iam_role.worker_role.arn
     }
     notebook = {
      desired_capacity = 1
@@ -88,6 +89,7 @@ module "eks" {
      }
      additional_tags = {
      }
+     iam_role_arn = data.aws_iam_role.worker_role.arn
     }
   }
 
@@ -103,6 +105,13 @@ module "eks" {
 
 }
 
+data aws_iam_role "worker_role" {
+   name = join("-", [var.cluster_name, "worker"])
+}
+
+data aws_iam_role "cluster_role" {
+   name = join("-", [var.cluster_name, "cluster"])
+}
 
 provider "helm" {
   kubernetes {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -39,7 +39,7 @@ module "eks" {
   cluster_version = var.cluster_version
 
   permissions_boundary = var.permissions_boundary
-  workers_additional_policies = [aws_iam_policy.cluster_autoscaler.arn] 
+  workers_additional_policies = [aws_iam_policy.cluster_autoscaler.arn]
   subnets      = local.private_subnet_ids
 
   cluster_endpoint_public_access = false
@@ -53,6 +53,11 @@ module "eks" {
 
   worker_create_security_group = true
   worker_security_group_id = data.aws_security_group.worker_sg.id
+
+  manage_cluster_iam_resources = false
+  manage_worker_iam_resources = false
+  workers_role_name = join("", [var.cluster_name, "-worker"])
+  cluster_iam_role_name = join("", [var.cluster_name, "-cluster"])
 
   node_groups_defaults = {
     ami_type  = "AL2_x86_64"

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -38,8 +38,6 @@ module "eks" {
   cluster_name = var.cluster_name
   cluster_version = var.cluster_version
 
-  permissions_boundary = var.permissions_boundary
-  workers_additional_policies = [aws_iam_policy.cluster_autoscaler.arn]
   subnets      = local.private_subnet_ids
 
   cluster_endpoint_public_access = false

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -106,11 +106,11 @@ module "eks" {
 }
 
 data aws_iam_role "worker_role" {
-   name = join("-", [var.cluster_name, "worker"])
+   name = "${var.cluster_name}-worker"
 }
 
 data aws_iam_role "cluster_role" {
-   name = join("-", [var.cluster_name, "cluster"])
+   name = "${var.cluster_name}-cluster"
 }
 
 provider "helm" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -36,11 +36,6 @@ variable "map_users" {
   ]
 }
 
-variable "permissions_boundary" {
-  description = "Specify the policy that enforces permissions boundaries"
-  type = string
-}
-
 variable "rolearn" {
   description = "ARN of the primary deployment role"
   type = string

--- a/aws/your-vars.tfvars.template
+++ b/aws/your-vars.tfvars.template
@@ -9,8 +9,6 @@ cluster_version = "1.18"
 
 allowed_roles = ["<DEPLOY-ROLE>"]   
 
-permissions_boundary = "arn:aws:iam::<account-id>:policy/<perm-boundary-policy>"
-
 rolearn = "arn:aws:iam::<account-id>:role/jupyterhub-admin"
 
 username = "jupyterhub-admin"


### PR DESCRIPTION
Intended to shift EKS created roles to ITSD.   Seems to work with e.g. roman-cluster and roman-worker prefab roles from ITSD.   This lets us avoid use of semi-random EKS role names which ITSD later adds to the perm-boundary by dropping creation of these roles at all.