### PR TITLE
Pin versions

### DIFF
--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -2,6 +2,7 @@
 module "iam_assumable_role_admin" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "~> 3.3.0"
+  depends_on = [null_resource.kubectl_config,  module.eks]
 
   create_role                   = false
   role_name                     = "${module.eks.cluster_id}-cluster-autoscaler"
@@ -16,7 +17,7 @@ resource "helm_release" "cluster-autoscaler" {
   repository = "https://charts.helm.sh/stable/"
   chart = "cluster-autoscaler"
   version = "7.2.0"    # documented as requiring exact version,  not ~>
-  depends_on = [null_resource.kubectl_config]
+  depends_on = [null_resource.kubectl_config,  module.eks]
 
   values = [
     file("cluster-autoscaler-values.yml")

--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -1,7 +1,8 @@
 # Create IAM role + automatically make it available to cluster autoscaler service account
 module "iam_assumable_role_admin" {
-  # See versions.tf for source and version
-  
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "~> 3.3.0"
+
   create_role                   = false
   role_name                     = "${module.eks.cluster_id}-cluster-autoscaler"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -1,11 +1,7 @@
-terraform {
-  required_version = ">= 0.13"
-}
-
 # Create IAM role + automatically make it available to cluster autoscaler service account
 module "iam_assumable_role_admin" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v3.3.0"
+  # See versions.tf for source and version
+  
   create_role                   = false
   role_name                     = "${module.eks.cluster_id}-cluster-autoscaler"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
@@ -18,7 +14,7 @@ resource "helm_release" "cluster-autoscaler" {
   namespace = "kube-system"
   repository = "https://charts.helm.sh/stable/"
   chart = "cluster-autoscaler"
-  version = "7.2.0"
+  version = "7.2.0"    # documented as requiring exact version,  not ~>
   depends_on = [null_resource.kubectl_config]
 
   values = [

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -24,6 +24,7 @@ resource "aws_security_group" "home_dirs_sg" {
 
 # XXXX should the EFS subnets be public or private?
 resource "aws_efs_mount_target" "home_dirs_targets" {
+  depends_on = [null_resource.kubectl_config]
   count = length(local.private_subnet_ids)
   file_system_id = aws_efs_file_system.home_dirs.id
   subnet_id = local.private_subnet_ids[count.index]
@@ -37,6 +38,7 @@ resource "kubernetes_namespace" "support" {
 }
 
 resource "helm_release" "efs-provisioner" {
+  depends_on = [null_resource.kubectl_config]
   name = "${var.cluster_name}-efs-provisioner"
   namespace = kubernetes_namespace.support.metadata.0.name
 

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -38,7 +38,7 @@ resource "kubernetes_namespace" "support" {
 }
 
 resource "helm_release" "efs-provisioner" {
-  depends_on = [null_resource.kubectl_config]
+  depends_on = [null_resource.kubectl_config, module.eks]
   name = "${var.cluster_name}-efs-provisioner"
   namespace = kubernetes_namespace.support.metadata.0.name
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -12,8 +12,9 @@ data "aws_availability_zones" "available" {
 }
 
 module "eks" {
-  # See version.tf for source and version
-  
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 13.2.1"
+
   cluster_name = var.cluster_name
   cluster_version = var.cluster_version
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,17 +1,3 @@
-
-terraform {
-  required_version = ">= 0.12.6"
-}
-
-provider "aws" {
-  version = ">= 2.28.1"
-  region  = var.region
-}
-
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }
@@ -22,19 +8,12 @@ data "aws_eks_cluster_auth" "cluster" {
 
 data "aws_caller_identity" "current" {}
 
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11.1"
-}
-
 data "aws_availability_zones" "available" {
 }
 
 module "eks" {
-  source       = "terraform-aws-modules/eks/aws"
+  # See version.tf for source and version
+  
   cluster_name = var.cluster_name
   cluster_version = var.cluster_version
 
@@ -110,15 +89,6 @@ data aws_iam_role "worker_role" {
 data aws_iam_role "cluster_role" {
    name = "${var.cluster_name}-cluster"
 }
-
-provider "helm" {
-  kubernetes {
-    host                   = data.aws_eks_cluster.cluster.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-    token                  = data.aws_eks_cluster_auth.cluster.token
-  }
-}
-
 
 resource "null_resource" "kubectl_config" {
   depends_on = [module.eks]

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -4,11 +4,11 @@ terraform {
       provider "aws" {
           source  = "hashicorp/aws"
           version = "~> 3.26.0"
-  	  region  = var.region
+          region  = var.region
       }
       provider "template" {
           source  = "hashicorp/template"
-      	  version = "~> 2.1"
+          version = "~> 2.1"
       }
       provider "kubernetes" {
           source                 = "hashicorp/kubernetes"
@@ -20,27 +20,16 @@ terraform {
       }
       provider "helm" {
           source = "hashicorp/helm"
-	  version = "~> 2.0.2"
-      	  kubernetes {
-    	      host                   = data.aws_eks_cluster.cluster.endpoint
-    	      cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-    	      token                  = data.aws_eks_cluster_auth.cluster.token
+          version = "~> 2.0.2"
+          kubernetes {
+              host                   = data.aws_eks_cluster.cluster.endpoint
+              cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+              token                  = data.aws_eks_cluster_auth.cluster.token
           }
       }
       provider "null" {
           source = "hashicorp/null"
-	  version = "~> 3.0.0"
+          version = "~> 3.0.0"
       }
    }
 }
-
-module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "~> 13.2.1"
-}
-
-module "iam_assumable_role_admin" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "~> 3.3.0"
-}
-

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -10,15 +10,15 @@ terraform {
           version = "~> 2.1"
       }
       kubernetes = {
-          source                 = "hashicorp/kubernetes"
-          version                = "~> 1.11.1"
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.1"
       }
       helm = {
-          source = "hashicorp/helm"
+          source  = "hashicorp/helm"
           version = "~> 2.0.2"
       }
       null = {
-          source = "hashicorp/null"
+          source  = "hashicorp/null"
           version = "~> 3.0.0"
       }
    }
@@ -42,4 +42,3 @@ provider "helm" {
      token                  = data.aws_eks_cluster_auth.cluster.token
   }
 }
-

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,20 +1,46 @@
 terraform {
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-    }
-    helm = {
-      source = "hashicorp/helm"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-    }
-    null = {
-      source = "hashicorp/null"
-    }
-    template = {
-      source = "hashicorp/template"
-    }
-  }
-  required_version = ">= 0.13"
+   required_version = "~> 0.14.5"
+   required_providers {
+      provider "aws" {
+          source  = "hashicorp/aws"
+          version = "~> 3.26.0"
+  	  region  = var.region
+      }
+      provider "template" {
+          source  = "hashicorp/template"
+      	  version = "~> 2.1"
+      }
+      provider "kubernetes" {
+          source                 = "hashicorp/kubernetes"
+          version                = "~> 1.11.1"
+          host                   = data.aws_eks_cluster.cluster.endpoint
+          cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+          token                  = data.aws_eks_cluster_auth.cluster.token
+          load_config_file       = false
+      }
+      provider "helm" {
+          source = "hashicorp/helm"
+	  version = "~> 2.0.2"
+      	  kubernetes {
+    	      host                   = data.aws_eks_cluster.cluster.endpoint
+    	      cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    	      token                  = data.aws_eks_cluster_auth.cluster.token
+          }
+      }
+      provider "null" {
+          source = "hashicorp/null"
+	  version = "~> 3.0.0"
+      }
+   }
 }
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 13.2.1"
+}
+
+module "iam_assumable_role_admin" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "~> 3.3.0"
+}
+

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,35 +1,45 @@
 terraform {
    required_version = "~> 0.14.5"
    required_providers {
-      provider "aws" {
+      aws = {
           source  = "hashicorp/aws"
           version = "~> 3.26.0"
-          region  = var.region
       }
-      provider "template" {
+      template = {
           source  = "hashicorp/template"
           version = "~> 2.1"
       }
-      provider "kubernetes" {
+      kubernetes = {
           source                 = "hashicorp/kubernetes"
           version                = "~> 1.11.1"
-          host                   = data.aws_eks_cluster.cluster.endpoint
-          cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-          token                  = data.aws_eks_cluster_auth.cluster.token
-          load_config_file       = false
       }
-      provider "helm" {
+      helm = {
           source = "hashicorp/helm"
           version = "~> 2.0.2"
-          kubernetes {
-              host                   = data.aws_eks_cluster.cluster.endpoint
-              cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-              token                  = data.aws_eks_cluster_auth.cluster.token
-          }
       }
-      provider "null" {
+      null = {
           source = "hashicorp/null"
           version = "~> 3.0.0"
       }
    }
 }
+
+provider "aws" {
+  region  = var.region
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
+provider "helm" {
+  kubernetes {
+     host                   = data.aws_eks_cluster.cluster.endpoint
+     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+     token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+

--- a/kms-codecommit/kms.tf
+++ b/kms-codecommit/kms.tf
@@ -21,6 +21,7 @@ EOF
 
 module "s3_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 1.17.0"
 
   bucket = var.sops_s3_bucket
   acl    = "private"

--- a/kms-codecommit/main.tf
+++ b/kms-codecommit/main.tf
@@ -1,14 +1,16 @@
 terraform {
-  required_version = ">= 0.13"
-}
+  required_version = "~> 0.14.5"
 
-provider "aws" {
-  version = ">= 2.28.1"
-  region  = var.region
-}
+  provider "aws" {
+      source  = "hashicorp/aws"
+      version = "~> 3.26.0"
+      region  = var.region
+  }
 
-provider "template" {
-  version = "~> 2.1"
+  provider "template" {
+      source  = "hashicorp/template"
+      version = "~> 2.1"
+  }
 }
 
 resource "aws_codecommit_repository" "secrets_repo" {

--- a/kms-codecommit/main.tf
+++ b/kms-codecommit/main.tf
@@ -1,16 +1,20 @@
 terraform {
   required_version = "~> 0.14.5"
 
-  provider "aws" {
-      source  = "hashicorp/aws"
-      version = "~> 3.26.0"
-      region  = var.region
+  required_providers {
+      aws = {
+          source  = "hashicorp/aws"
+          version = "~> 3.26.0"
+      }
+      template = {
+          source  = "hashicorp/template"
+          version = "~> 2.1"
+      }
   }
+}
 
-  provider "template" {
-      source  = "hashicorp/template"
-      version = "~> 2.1"
-  }
+provider "aws" {
+  region  = var.region
 }
 
 resource "aws_codecommit_repository" "secrets_repo" {


### PR DESCRIPTION
This PR pins the versions of Terraform, Providers, and Modules in an attempt to prevent troublesome version changes.   The pinning is done using the ~> operator so that pinning versions x.y.z later does permit x.y.z+1,  x.y.z+2,  etc,  where only z is permitted to change.

I also added dependency relationships to the efs home dir targets and efs provisioner which seemed to enable terraform-deploy/aws to stand up correctly the first time.