### PR TITLE
Terraform version updates, instance type update

### DIFF
--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -1,7 +1,7 @@
 # Create IAM role + automatically make it available to cluster autoscaler service account
 module "iam_assumable_role_admin" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "~> 3.3.0"
+  version = "~> 4.2.0"
   depends_on = [null_resource.kubectl_config,  module.eks]
 
   create_role                   = false
@@ -12,18 +12,16 @@ module "iam_assumable_role_admin" {
 
 resource "helm_release" "cluster-autoscaler" {
   name = "cluster-autoscaler"
-  # Check that this is good, kube-system should already exist
   namespace = "kube-system"
-  repository = "https://charts.helm.sh/stable/"
+  repository = "https://kubernetes.github.io/autoscaler"
   chart = "cluster-autoscaler"
-  version = "7.2.0"    # documented as requiring exact version,  not ~>
+  version = "9.10.3"
   depends_on = [null_resource.kubectl_config,  module.eks]
 
   values = [
     file("cluster-autoscaler-values.yml")
   ]
 
-  # Terraform keeps this in state, so we get it automatically!
   set{
     name = "awsRegion"
     value = var.region

--- a/aws/cluster-autoscaler-values.yml
+++ b/aws/cluster-autoscaler-values.yml
@@ -5,3 +5,10 @@ cloudProvider: aws
 
 autoDiscovery:
   enabled: true
+  clusterName: jwebbinar
+  tags:
+  - k8s.io/cluster-autoscaler/enabled
+  - k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}
+  #roles:
+  #- worker
+

--- a/aws/cluster-autoscaler-values.yml
+++ b/aws/cluster-autoscaler-values.yml
@@ -5,10 +5,3 @@ cloudProvider: aws
 
 autoDiscovery:
   enabled: true
-  clusterName: jwebbinar
-  tags:
-  - k8s.io/cluster-autoscaler/enabled
-  - k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}
-  #roles:
-  #- worker
-

--- a/aws/local.tf
+++ b/aws/local.tf
@@ -11,4 +11,11 @@ locals {
        private_subnet_names = [for s in data.aws_subnet.private : s.tags["Name"]]
 
        vpc_id = data.aws_vpc.unmanaged[0].id
+
+       rolearn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.username}"
 }
+
+
+data aws_caller_identity current { }
+
+

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -28,6 +28,10 @@ output "node_groups" {
   value       = module.eks.node_groups
 }
 
+output "rolearn" {
+   description = "EKS role arn"
+   value = local.rolearn
+}
 
 # -------------------------------------------------------------------
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -36,11 +36,6 @@ variable "map_users" {
   ]
 }
 
-variable "rolearn" {
-  description = "ARN of the primary deployment role"
-  type = string
-}
-
 variable "username" {
   description = "The name of the primary deployment role"
   type = string
@@ -87,7 +82,7 @@ variable worker_sg_name {
 variable notebook_instance_type {
    description = "EC2 instance type used for notebook sessions."
    type = string
-   default = "t3.xlarge"
+   default = "r5.xlarge"
 }
 
 # ========================================================================
@@ -97,6 +92,6 @@ variable allowed_roles {
 
 variable cluster_version {
     description = "Kubernetes version used by the EKS module."
-    default = "1.17"
+    default = "1.21"
     type = string
 }

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -2,27 +2,39 @@ terraform {
    backend "s3" {  
      # backend file expected to fill in here, vars not allowed 
    }
-   required_version = "~> 0.14.5"
+   required_version = "~> 1.0.3"
    required_providers {
       aws = {
           source  = "hashicorp/aws"
-          version = "~> 3.26.0"
+          version = "~> 3.51.0"
       }
       template = {
           source  = "hashicorp/template"
-          version = "~> 2.1"
+          version = "~> 2.2.0"
       }
       kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.11.1"
+          version = "~> 2.3.2"
+      }
+      cloudinit = {
+	  source = "hashicorp/cloudinit"
+	  version = "~> 2.2.0"
       }
       helm = {
           source  = "hashicorp/helm"
-          version = "~> 2.0.2"
+          version = "~> 2.2.0"
       }
       null = {
           source  = "hashicorp/null"
-          version = "~> 3.0.0"
+          version = "~> 3.1.0"
+      }
+      local = {
+          source = "hashicorp/local"
+          version = "~> 2.1.0"
+      }
+      http = {
+          source = "terraform-aws-modules/http"
+          version = "~> 2.4.1"
       }
    }
 }
@@ -35,7 +47,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
+  #load_config_file       = false
 }
 
 provider "helm" {

--- a/aws/your-vars.tfvars.template
+++ b/aws/your-vars.tfvars.template
@@ -5,13 +5,9 @@ region = "us-east-1"
 cluster_name = "<YOUR-CLUSTER>"
 
 # Version of k8s used by EKS
-cluster_version = "1.18"
+cluster_version = "1.21"
 
-allowed_roles = ["<DEPLOY-ROLE>"]   
-
-rolearn = "arn:aws:iam::<account-id>:role/jupyterhub-admin"
-
-username = "jupyterhub-admin"
+username = "<DEPLOY-ROLE>"
 
 # ============================================================================================================
 

--- a/kms-codecommit/kms.tf
+++ b/kms-codecommit/kms.tf
@@ -21,7 +21,7 @@ EOF
 
 module "s3_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 1.17.0"
+  version = "~> 2.6.0"
 
   bucket = var.sops_s3_bucket
   acl    = "private"

--- a/kms-codecommit/main.tf
+++ b/kms-codecommit/main.tf
@@ -2,16 +2,16 @@ terraform {
   backend "s3" {
     # backend file expected to fill in here, vars not allowed
   }
-  required_version = "~> 0.14.5"
+  required_version = "~> 1.0.3"
 
   required_providers {
       aws = {
           source  = "hashicorp/aws"
-          version = "~> 3.26.0"
+          version = "~> 3.51.0"
       }
       template = {
           source  = "hashicorp/template"
-          version = "~> 2.1"
+          version = "~> 2.2.0"
       }
   }
 }

--- a/kms-codecommit/your-vars.tfvars.template
+++ b/kms-codecommit/your-vars.tfvars.template
@@ -1,7 +1,7 @@
 region = "us-east-1"
 
 repo_name = "<deployment-name>-secrets"
-sops_s3_bucket = "<deployment-name>-sops-config"
+sops_s3_bucket = "<deployment-name>-sops-config-<environment>"
 sops_s3_source= ".sops.yaml"
 sops_s3_key = ".sops.yaml"
 


### PR DESCRIPTION
Switch to instance_types = ["r5.xlarge"] in for notebook nodegroup.
Upgrade provider, module, and resource pinned versions,  switch to supported autoscaler repo.
Simplified configuration by computing rolearn and ditching allowed_roles.
Test vs. Terraform-1.0.3 OK
Update k8s version to 1.21
There's a corresponding CI-node template update on Tike TEST which needs to be made default to install Terraform-1.0.3.